### PR TITLE
Changed gemfile version to match VERSION file

### DIFF
--- a/pcap_simple.gemspec
+++ b/pcap_simple.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{pcap_simple}
-  s.version = "0.2.0"
+  s.version = "0.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ryan Breed"]


### PR DESCRIPTION
.gemspec file still had version as 0.2.0, so the generated gemfile was named pcap_simple-0.2.0.gem instead of pcap_simple-0.3.0.gem.

I'm no gem expert, but this seems like the right thing to do.. if not, maybe add a comment in the gemspec file?
